### PR TITLE
fixed unreadable dummy names

### DIFF
--- a/core/gdcp.py
+++ b/core/gdcp.py
@@ -70,6 +70,7 @@ class ReduceGDtoCP:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         self.num_of_relations = len(self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)
 

--- a/core/gdelim.py
+++ b/core/gdelim.py
@@ -41,6 +41,7 @@ class Elim:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         assert (self.implication_relations == []), "Marking algorithm doesn't support implication relations"
         self.num_of_relations = len(self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)

--- a/core/gdgroebner.py
+++ b/core/gdgroebner.py
@@ -68,6 +68,7 @@ class ReduceGDtoGroebner:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         self.num_of_relations = len(
             self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)

--- a/core/gdmark.py
+++ b/core/gdmark.py
@@ -41,6 +41,7 @@ class Mark:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         assert (self.implication_relations == []), "Marking algorithm doesn't support implication relations"
         self.num_of_relations = len(self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)

--- a/core/gdmilp.py
+++ b/core/gdmilp.py
@@ -55,6 +55,7 @@ class ReduceGDtoMILP:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         self.num_of_relations = len(
             self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)

--- a/core/gdsat.py
+++ b/core/gdsat.py
@@ -61,6 +61,7 @@ class ReduceGDtoSAT:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         self.num_of_relations = len(
             self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)

--- a/core/gdsmt.py
+++ b/core/gdsmt.py
@@ -64,6 +64,7 @@ class ReduceGDtoSMT:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         self.num_of_relations = len(
             self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)

--- a/core/gdz3smt.py
+++ b/core/gdz3smt.py
@@ -56,6 +56,7 @@ class ReduceGDtoZ3SMT:
         self.notguessed_variables = parsed_data['notguessed_variables']
         self.symmetric_relations = parsed_data['symmetric_relations']
         self.implication_relations = parsed_data['implication_relations']
+        self.dummy_mapping = parsed_data.get('dummy_mapping', {})
         self.num_of_relations = len(
             self.symmetric_relations) + len(self.implication_relations)
         self.num_of_vars = len(self.variables)

--- a/core/inputparser.py
+++ b/core/inputparser.py
@@ -49,6 +49,7 @@ def read_relation_file(path, preprocess=1, D=2, log=0):
     problem_name = find_problem_name(contents)
     sections = split_contents_by_sections(remove_comments(contents))
 
+    dummy_mapping = {}
     connection_relations = sections.get('connection relations', '')
     algebraic_relations = sections.get('algebraic relations', '')
     algebraic_equations_file = os.path.join(TEMP_DIR, 'algebraic_equations_%s.txt' % rnd_string_tmp)
@@ -74,14 +75,16 @@ def read_relation_file(path, preprocess=1, D=2, log=0):
         algebraic_relations += '\n' + groebner_basis
         # algebraic_relations = groebner_basis
         if connection_relations == '':
-            connection_relations = algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
+            connection_relations, dummy_mapping = algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
         else:
-            connection_relations += '\n' + algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
+            cr, dummy_mapping = algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
+            connection_relations += '\n' + cr
     elif algebraic_relations != '' and preprocess == 0:
         if connection_relations == '':
-            connection_relations = algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
+            connection_relations, dummy_mapping = algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
         else:
-            connection_relations += '\n' + algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
+            cr, dummy_mapping = algebraic_relations_to_connection_relations(algebraic_relations.split('\n'))
+            connection_relations += '\n' + cr
     symmetric_relations, implication_relations, variables = parse_connection_relations(connection_relations)
     known_variables = sections.get('known', [])
     if known_variables != []:
@@ -112,7 +115,8 @@ def read_relation_file(path, preprocess=1, D=2, log=0):
                    'target_weights' : target_weights,
                    'notguessed_variables': notguessed_variables,
                    'symmetric_relations': symmetric_relations,
-                   'implication_relations': implication_relations}
+                   'implication_relations': implication_relations,
+                   'dummy_mapping': dummy_mapping}
     if log == 0 and algebraic_relations != '' and preprocess == 1:
         os.remove(algebraic_equations_file)
         os.remove(macaulay_basis_file)
@@ -305,9 +309,14 @@ def algebraic_relations_to_connection_relations(algebraic_relations):
     """
     Generate the connection relations derived from the given algebraic relations by introducing new variables
     It currently work for boolean polynomial relations merely
+    Also creates a mapping from dummy variables to original monomials.
+    Returns:
+        connection_relations_str: string of relations
+        dummy_mapping: dictionary {dummy_var: [original variables]}
     """
 
     connection_relations = []
+    dummy_mapping = dict()
     if algebraic_relations[-1] == '':
         algebraic_relations[-1:] = []
     algebraic_relations = [poly.replace(' ', '') for poly in algebraic_relations]
@@ -323,6 +332,7 @@ def algebraic_relations_to_connection_relations(algebraic_relations):
             dummy_var = "{0}{1}".format(dummy_vars_prefix, "".join(var_indices))
             if dummy_var not in substitution_dictionary.values():
                 connection_relations.append("{0}=>{1}".format(",".join(monomial_variables), dummy_var))
+                dummy_mapping[dummy_var] = monomial_variables  # Record dummy → original vars
             substitution_dictionary[monomial] = dummy_var
 
     for poly in algebraic_relations:
@@ -332,4 +342,4 @@ def algebraic_relations_to_connection_relations(algebraic_relations):
         if '0' in linearized_relation:
             linearized_relation.remove('0')
         connection_relations.append(",".join(linearized_relation))
-    return "\n".join(connection_relations)
+    return "\n".join(connection_relations), dummy_mapping

--- a/core/parsesolution.py
+++ b/core/parsesolution.py
@@ -21,8 +21,16 @@ def parse_solver_solution(gd):
     gd.final_info = sum(gd.solutions[gd.max_steps].values())
     print('Number of guesses: %d' % numbers_of_guesses)
     print('Number of known variables in the final state: %d out of %d' % (gd.final_info, len(gd.variables)))
-    print('The following %d variable(s) are guessed:' % len(gd.guessed_vars))
-    print(', '.join(gd.guessed_vars))
+    if hasattr(gd, "dummy_mapping"):
+        guessed_vars_pretty = []
+        for v in gd.guessed_vars:
+            if v in gd.dummy_mapping:
+                guessed_vars_pretty.append(f"{v} (represents: {' * '.join(gd.dummy_mapping[v])})")
+            else:
+                guessed_vars_pretty.append(v)
+        print(f"The following {len(gd.guessed_vars)} variable(s) are guessed:\n{', '.join(guessed_vars_pretty)}")
+    else:
+        print(f"The following {len(gd.guessed_vars)} variable(s) are guessed:\n{', '.join(gd.guessed_vars)}")
     
     separator_line = '#' * 60
     output_buffer = ''
@@ -36,7 +44,13 @@ def parse_solver_solution(gd):
     output_buffer += 'An upper bound for the number of guessed variables given by user (max_guess): %d\n' % gd.max_guess
     output_buffer += '%d out of %d state variables are known after %d state copies\n' % (gd.final_info, gd.num_of_vars, gd.max_steps)
     output_buffer += separator_line
-    output_buffer += '\nThe following %d variable(s) are guessed:\n%s\n' % (len(gd.guessed_vars), ', '.join(gd.guessed_vars))
+    guessed_vars_pretty = []
+    for v in gd.guessed_vars:
+        if hasattr(gd, "dummy_mapping") and v in gd.dummy_mapping:
+            guessed_vars_pretty.append(f"{v} (represents: {' * '.join(gd.dummy_mapping[v])})")
+        else:
+            guessed_vars_pretty.append(v)
+    output_buffer += f"\nThe following {len(gd.guessed_vars)} variable(s) are guessed:\n{', '.join(guessed_vars_pretty)}\n"
     output_buffer += separator_line
     output_buffer += '\nThe following %d variable(s) are initially known:\n%s\n' % (len(gd.known_variables), ', '.join(gd.known_variables))
     output_buffer += separator_line


### PR DESCRIPTION
From this [issue](https://github.com/hadipourh/autoguess/issues/7), fixed the renaming.
Output now prints "FPWB03 (represents X1*X4)" to avoid confusion with raw variable names.